### PR TITLE
Add clickable IATI Identifier with link to D-Portal

### DIFF
--- a/components/DataBrowser.vue
+++ b/components/DataBrowser.vue
@@ -65,6 +65,11 @@
                 small
                 :items="cells"
                 :fields="tableFields">
+                <template #[iatiIdentifierSlotName]="data">
+                  <a
+                  :href="`https://d-portal.org/savi/?aid=${data.item['activity.iati_identifier']}`"
+                  target="_blank">{{ data.item['activity.iati_identifier'] }}</a>
+                </template>
               </b-table>
             </b-col>
           </b-row>
@@ -154,6 +159,9 @@ export default {
     }
   },
   computed: {
+    iatiIdentifierSlotName() {
+      return `cell(activity.iati_identifier)`
+    },
     optionsToBeSelected() {
       return (this.startedLoading==false) && (this.autoReload==false)
     },

--- a/pages/data/countries/_code/index.vue
+++ b/pages/data/countries/_code/index.vue
@@ -102,7 +102,7 @@
       <b-col md="12" class="mt-2">
         <h3>by Activity</h3>
         <DataBrowser
-          :drilldowns="['activity.title']"
+          :drilldowns="['activity.iati_identifier', 'activity.title']"
           displayAs="table"
           :setFields="setFields"
           :currency.sync="currency"

--- a/pages/data/providers/_code/index.vue
+++ b/pages/data/providers/_code/index.vue
@@ -104,7 +104,7 @@
       <b-col md="12" class="mt-2">
         <h3>by Activity</h3>
         <DataBrowser
-          :drilldowns="['activity.title']"
+          :drilldowns="['activity.iati_identifier', 'activity.title']"
           displayAs="table"
           :setFields="setFields"
           :currency.sync="currency"

--- a/pages/data/sectors/_code/index.vue
+++ b/pages/data/sectors/_code/index.vue
@@ -104,7 +104,7 @@
       <b-col md="12" class="mt-2">
         <h3>by Activity</h3>
         <DataBrowser
-          :drilldowns="['activity.title']"
+          :drilldowns="['activity.iati_identifier', 'activity.title']"
           displayAs="table"
           :setFields="setFields"
           :currency.sync="currency"


### PR DESCRIPTION
When showing lists of activities, make it possible to click to view detailed information about the same activity on D-Portal