### PR TITLE
Fixes for Safari; make custom data field columns sortable; make drilldowns clickable from summary page

### DIFF
--- a/components/BarChartComponent.vue
+++ b/components/BarChartComponent.vue
@@ -43,10 +43,22 @@ export default {
     },
     'height': {
       default: '400px'
+    },
+    'selectedDrilldown': {
+      default() { return function () {} }
     }
   },
   components: {
     BarChart
+  },
+  methods: {
+    handleClick(evt, item) {
+      if (this.clickable == false) { return }
+      if (item.length == 0) { return }
+      const itemIndex = item[0]._index
+      const cell = this.cells[item[0]._index]
+      this.selectedDrilldown(cell[`${this.drilldown}.code`])
+    }
   },
   computed: {
     barChartHeight() {
@@ -54,6 +66,11 @@ export default {
     },
     barChartOptions(){
       return {
+        onClick: this.handleClick,
+        onHover: (event, chartElement) => {
+          if (this.clickable == false) { return }
+          event.target.style.cursor = chartElement[0] ? 'pointer' : 'default';
+        },
         maintainAspectRatio: false,
         tooltips: {
           callbacks: {

--- a/components/DataBrowser.vue
+++ b/components/DataBrowser.vue
@@ -61,6 +61,8 @@
                 :drilldown="drilldowns[0]"
                 :datasets="barChartDatasets"
                 :height="barChartHeight"
+                :clickable="clickable"
+                :selectedDrilldown.sync="selectedDrilldown"
               />
             </b-col>
             <b-col v-if="displayAs=='table'">
@@ -72,6 +74,12 @@
                   <a
                   :href="`https://d-portal.org/savi/?aid=${data.item['activity.iati_identifier']}`"
                   target="_blank">{{ data.item['activity.iati_identifier'] }}</a>
+                </template>
+                <template #[clickableDrilldownSlotName]="data">
+                  <nuxt-link :to="localePath({
+                    name: selectedDrilldownPath,
+                    params: { code: data.item[`${drilldowns[0]}.code`] }
+                  })">{{ data.item[`${drilldowns[0]}.name_${lang}`] }}</nuxt-link>
                 </template>
               </b-table>
             </b-col>
@@ -189,8 +197,25 @@ export default {
     }
   },
   computed: {
+    selectedDrilldownPath() {
+      const d = this.drilldowns.join('')
+      if (d == 'reporting_organisation') {
+        return 'data-providers-code'
+      }
+      else if (d == 'recipient_country_or_region') {
+        return 'data-countries-code'
+      }
+      else if (d == 'sector_category') {
+        return 'data-sectors-code'
+      }
+    },
     iatiIdentifierSlotName() {
       return `cell(activity.iati_identifier)`
+    },
+    clickableDrilldownSlotName() {
+      if ((this.drilldowns.length == 1) && (this.clickable == true)) {
+        return `cell(${this.drilldowns[0]})`
+      }
     },
     optionsToBeSelected() {
       return (this.startedLoading==false) && (this.autoReload==false)
@@ -443,6 +468,12 @@ export default {
       if (this.request) {
         this.request.cancel()
         this.request = null;
+      }
+    },
+    selectedDrilldown(code) {
+      const path = this.selectedDrilldownPath
+      if (path) {
+        this.$router.push(this.localePath({name: path, params: { code: code }}))
       }
     }
   },

--- a/components/DataBrowserFilter.vue
+++ b/components/DataBrowserFilter.vue
@@ -79,11 +79,9 @@
       </b-col>
     </b-row>
     <b-modal v-model="showFilters" title="Filters" ok-only ok-title="Close" size="lg">
-      <b-card-group columns>
-        <b-card
-          border-variant="light"
-          body-class="p-2"
-          class="p-0"
+      <b-row cols="3" class="p-3">
+        <b-col
+          class="p-2"
           v-for="field in Object.keys(fields)"
           v-if="!excludeFilters.includes(field)"
           v-bind:key="field">
@@ -95,8 +93,8 @@
             :updateField="updateField"
             :value="setFields[field]">
           </DataBrowserFilterItem>
-        </b-card>
-      </b-card-group>
+        </b-col>
+      </b-row>
     </b-modal>
   </div>
 </template>

--- a/components/DataBrowserNavbar.vue
+++ b/components/DataBrowserNavbar.vue
@@ -43,14 +43,29 @@
 <style lang="scss">
 .navbar-secondary {
   background-color: #eee !important;
-  .nav-item .btn-link {
-    color: #007bff;
-    &:hover, &:focus {
+  .btn-link {
+    color: #155366 !important;
+    &:hover, &:focus, &:active {
       color: #ffffff;
     }
   }
-  .nav-item .btn-link.btn-primary {
-    color: #ffffff;
+  .btn-outline-primary {
+    color: #155366 !important;
+    border-color: #155366;
+    &:hover, &:focus, &:active {
+      color: #ffffff !important;
+      border-color: #06DBE4 !important;
+      background-color: #06DBE4 !important;
+    }
+  }
+  .btn-primary {
+    color: #ffffff !important;
+    background-color: #155366;
+    border-color: #155366;
+    &:hover, &:focus, &:active {
+      background-color: #06DBE4 !important;
+      border-color: #06DBE4 !important;
+    }
   }
 }
 .collapse.show .hide-on-collapse {

--- a/nuxt.config-live.tmpl.js
+++ b/nuxt.config-live.tmpl.js
@@ -40,10 +40,14 @@ export default {
   ],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: ['~/plugins/local-components.js', '~/plugins/vue-select.js', {
-    src: '~/plugins/leaflet.js',
-    mode: 'client'
-  }
+  plugins: ['~/plugins/local-components.js', '~/plugins/vue-select.js',
+    {
+      src: '~/plugins/leaflet.js',
+      mode: 'client'
+    },
+    {
+      src: '~plugins/vuedraggable.js'
+    }
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/nuxt.config.tmpl.js
+++ b/nuxt.config.tmpl.js
@@ -31,10 +31,14 @@ export default {
   ],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: ['~/plugins/local-components.js', '~/plugins/vue-select.js', {
-    src: '~/plugins/leaflet.js',
-    mode: 'client'
-  }
+  plugins: ['~/plugins/local-components.js', '~/plugins/vue-select.js',
+    {
+      src: '~/plugins/leaflet.js',
+      mode: 'client'
+    },
+    {
+      src: '~plugins/vuedraggable.js'
+    }
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,11 @@
         "transliteration": "^2.3.5",
         "vue": "^2.6.14",
         "vue-chartjs": "^3.5.1",
-        "vue-select": "^3.20.0",
+        "vue-select": "^3.20.2",
         "vue-server-renderer": "^2.6.14",
         "vue-template-compiler": "^2.6.14",
         "vue2-leaflet": "^2.7.1",
+        "vuedraggable": "^2.24.3",
         "webpack": "^4.46.0"
       },
       "devDependencies": {
@@ -13919,6 +13920,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -15655,9 +15661,9 @@
       "integrity": "sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ=="
     },
     "node_modules/vue-select": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.20.0.tgz",
-      "integrity": "sha512-Qau4BzpgAC+/9jM5oTlOrfA81ONdtTFH6PqeSDKvIB56f1F6EbIR8qAotpUxrIiNVppyPFjvVDkyriMfHjWBQA==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.20.2.tgz",
+      "integrity": "sha512-ZSzIDzyYsWZULGUxVp1h6u3yi9IZQBWX8r6kSudUI/I5J1HQKpBjRntvkrg6pr87xmm16kdChvHCDN+W84vTKw==",
       "peerDependencies": {
         "vue": "2.x"
       }
@@ -15753,6 +15759,14 @@
         "@types/leaflet": "^1.5.7",
         "leaflet": "^1.3.4",
         "vue": "^2.5.17"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+      "dependencies": {
+        "sortablejs": "1.10.2"
       }
     },
     "node_modules/vuex": {
@@ -27819,6 +27833,11 @@
         }
       }
     },
+    "sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -29135,9 +29154,9 @@
       "integrity": "sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ=="
     },
     "vue-select": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.20.0.tgz",
-      "integrity": "sha512-Qau4BzpgAC+/9jM5oTlOrfA81ONdtTFH6PqeSDKvIB56f1F6EbIR8qAotpUxrIiNVppyPFjvVDkyriMfHjWBQA==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.20.2.tgz",
+      "integrity": "sha512-ZSzIDzyYsWZULGUxVp1h6u3yi9IZQBWX8r6kSudUI/I5J1HQKpBjRntvkrg6pr87xmm16kdChvHCDN+W84vTKw==",
       "requires": {}
     },
     "vue-server-renderer": {
@@ -29223,6 +29242,14 @@
       "resolved": "https://registry.npmjs.org/vue2-leaflet/-/vue2-leaflet-2.7.1.tgz",
       "integrity": "sha512-K7HOlzRhjt3Z7+IvTqEavIBRbmCwSZSCVUlz9u4Rc+3xGCLsHKz4TAL4diAmfHElCQdPPVdZdJk8wPUt2fu6WQ==",
       "requires": {}
+    },
+    "vuedraggable": {
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+      "requires": {
+        "sortablejs": "1.10.2"
+      }
     },
     "vuex": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vue-server-renderer": "^2.6.14",
     "vue-template-compiler": "^2.6.14",
     "vue2-leaflet": "^2.7.1",
+    "vuedraggable": "^2.24.3",
     "webpack": "^4.46.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "transliteration": "^2.3.5",
     "vue": "^2.6.14",
     "vue-chartjs": "^3.5.1",
-    "vue-select": "^3.20.0",
+    "vue-select": "^3.20.2",
     "vue-server-renderer": "^2.6.14",
     "vue-template-compiler": "^2.6.14",
     "vue2-leaflet": "^2.7.1",

--- a/pages/data/custom/index.vue
+++ b/pages/data/custom/index.vue
@@ -46,7 +46,8 @@
         <DataBrowserFilter
           :exclude-filters="['recipient_country_or_region',
             'reporting_organisation',
-            'sector_category']"
+            'sector_category',
+            'transaction_type']"
           :setFields.sync="setFields"
           :currency.sync="currency"
           :horizontal="false"

--- a/pages/data/custom/index.vue
+++ b/pages/data/custom/index.vue
@@ -10,9 +10,28 @@
           <v-select
             multiple
             :options="drilldownOptions"
-            v-model="drilldowns"
-            :reduce="drilldown => drilldown.value"
-            ></v-select>
+            v-model="drilldownsWithLabels"
+            >
+            <template #selected-option-container="{ option }">
+              <div class="hidden-option">{{ option }}</div>
+            </template>
+          </v-select>
+          <draggable v-model="drilldownsWithLabels"
+            ghost-class="hidden" @start="drag=true" @end="drag=false">
+            <div class="vs__selected draggable-item"
+              v-for="(drilldown, index) in drilldownsWithLabels"
+              :key="drilldown.value">
+                {{ drilldown.label }}
+                <button
+                  type="button"
+                  :title="`Deselect ${drilldown.label}`"
+                  :aria-label="`Deselect ${drilldown.label}`"
+                  class="vs__deselect"
+                 @click="$delete(drilldownsWithLabels, index)">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><path d="M6.895455 5l2.842897-2.842898c.348864-.348863.348864-.914488 0-1.263636L9.106534.261648c-.348864-.348864-.914489-.348864-1.263636 0L5 3.104545 2.157102.261648c-.348863-.348864-.914488-.348864-1.263636 0L.261648.893466c-.348864.348864-.348864.914489 0 1.263636L3.104545 5 .261648 7.842898c-.348864.348863-.348864.914488 0 1.263636l.631818.631818c.348864.348864.914773.348864 1.263636 0L5 6.895455l2.842898 2.842897c.348863.348864.914772.348864 1.263636 0l.631818-.631818c.348864-.348864.348864-.914489 0-1.263636L6.895455 5z"></path></svg>
+                </button>
+              </div>
+          </draggable>
         </b-form-group>
         <hr />
         <h3>Filters</h3>
@@ -71,6 +90,12 @@
 .custom-data-browser {
   min-height: 650px;
 }
+.draggable-item {
+  cursor:  grab;
+}
+.hidden-option {
+  display: none;
+}
 </style>
 <script>
 
@@ -89,7 +114,8 @@ export default {
         calendar_year_and_quarter: []
       },
       currency: 'usd',
-      autoReload: true
+      autoReload: true,
+      drilldownsWithLabels: []
     }
   },
   methods: {
@@ -98,6 +124,14 @@ export default {
     },
     updateField(field, values) {
       this.$set(this.setFields, field, values)
+    },
+    setDrilldownsWithLabels() {
+      this.drilldownsWithLabels = this.drilldowns.map(item => {
+        return {
+          value: item,
+          label: this.availableDrilldowns[item]
+        }
+      })
     }
   },
   computed: {
@@ -115,6 +149,16 @@ export default {
   },
   mounted: function() {
     this.$store.dispatch('getCodelists')
+    this.setDrilldownsWithLabels()
+  },
+  watch: {
+    drilldownsWithLabels: {
+      handler() {
+        this.drilldowns = this.drilldownsWithLabels.map(item => {
+          return item.value
+        })
+      }
+    }
   }
 }
 </script>

--- a/pages/data/custom/index.vue
+++ b/pages/data/custom/index.vue
@@ -6,7 +6,10 @@
       <b-col md="3" class="mt-2">
         <h3>Columns</h3>
         <b-form-group
-          label="Select columns">
+          label="Select columns"
+          :state="drilldowns.length == 0 ? false : true"
+          invalid-feedback="You must select at least one column"
+          :description="drilldowns.length > 1 ? 'Drag columns to reorder output' : null">
           <v-select
             multiple
             :options="drilldownOptions"

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -30,6 +30,7 @@
           displayAs="barChart"
           :setFields="setFields"
           :currency.sync="currency"
+          :clickable="true"
          />
       </b-col>
     </b-row>
@@ -41,6 +42,7 @@
           displayAs="barChart"
           :setFields="setFields"
           :currency.sync="currency"
+          :clickable="true"
          />
       </b-col>
     </b-row>

--- a/plugins/vuedraggable.js
+++ b/plugins/vuedraggable.js
@@ -1,0 +1,3 @@
+import Draggable from 'vuedraggable';
+import Vue from 'vue';
+Vue.component('draggable', Draggable);


### PR DESCRIPTION
* Disable transaction type from being selectable in the custom data pop-up because this is set elsewhere and could cause inconsistent behaviour
* A few fixes for Safari where some filters were not selectable
* Make custom filters draggable so that they can be re-ordered... unfortunately `vue-select` doesn't provide access to a wrapper around multiple options, so we have to create a separate space for the options to be displayed. This looks a bit different but I think it's OK.
* Make summary page drilldowns clickable

*Custom columns (before)*
![image](https://user-images.githubusercontent.com/688113/211618983-1b3ef9cd-9ed0-4dea-957b-e4e6c0180497.png)

*Custom columns (after)*
<img width="351" alt="image" src="https://user-images.githubusercontent.com/688113/211621830-51d41286-7541-48c0-9ece-a83e4ae5d1e4.png">