### PR TITLE
Translations filters

### DIFF
--- a/components/DataBrowserSource.vue
+++ b/components/DataBrowserSource.vue
@@ -1,0 +1,18 @@
+<template>
+  <b-row>
+    <b-col
+      class="mt-4 mb-2 text-muted font-italic">
+      <hr />
+      <i18n path="dataDashboards.dataSource" tag="p">
+        <nuxt-link
+          place="methodology"
+          :to="localePath({path:'/methodology/'})">{{ $t('aboutNav[1][1]') }}</nuxt-link>
+      </i18n>
+      <i18n path="dataDashboards.dataSourceContact" tag="p">
+        <a
+          place="emailContact"
+          :href="`mailto:${$t('dataDashboards.emailContact')}`">{{ $t('dataDashboards.emailContact') }}</a>
+      </i18n>
+    </b-col>
+  </b-row>
+</template>

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -38,8 +38,9 @@
 <download-file></download-file>
 
 </b-card>
-    <b-card body-class="d-flex align-items-center">
-        <b-btn block variant="primary" to="/data/custom/">Custom data download <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn>
+    <b-card>
+        <p><b-btn block variant="primary" to="/data/custom/">Custom data download <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn></p>
+        <p>Choose the columns to be included in your spreadsheet and select the filters to narrow your search. Download the custom set of data in Excel.</p>
     </b-card>
 </b-card-group>
 <hr />

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -40,8 +40,9 @@
 <download-file></download-file>
 
 </b-card>
-    <b-card body-class="d-flex align-items-center">
-        <b-btn block variant="primary" to="/es/data/custom/">Explorar los datos <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn>
+    <b-card>
+        <p><b-btn block variant="primary" to="/es/data/custom/">Descarga de datos personalizados <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn></p>
+        <p>Elija las columnas que se incluirán en su hoja de cálculo y seleccione los filtros para restringir su búsqueda. Descargue el conjunto personalizado de datos en Excel.</p>
     </b-card>
 </b-card-group>
 <hr />

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -41,8 +41,9 @@
 <download-file></download-file>
 
 </b-card>
-    <b-card body-class="d-flex align-items-center">
-        <b-btn block variant="primary" to="/fr/data/custom/">Explorez les données <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn>
+    <b-card>
+        <p><b-btn block variant="primary" to="/fr/data/custom/">Téléchargement de données personnalisées <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn></p>
+        <p>Choisissez les colonnes à inclure dans votre feuille de calcul et sélectionnez les filtres pour affiner votre recherche. Téléchargez l'ensemble de données personnalisé dans Excel.</p>
     </b-card>
 </b-card-group>
 <hr />

--- a/content/pt/index.md
+++ b/content/pt/index.md
@@ -40,8 +40,9 @@
 <download-file></download-file>
 
 </b-card>
-    <b-card body-class="d-flex align-items-center">
-        <b-btn block variant="primary" to="/pt/data/custom/">Descarga de datos personalizados <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn>
+    <b-card>
+        <p><b-btn block variant="primary" to="/pt/data/custom/">Descarga de datos personalizados <font-awesome-icon :icon="['fa', 'wand-magic-sparkles']" /></b-btn></p>
+        <p>Escolha as colunas a serem incluídas em sua planilha e selecione os filtros para refinar sua pesquisa. Baixe o conjunto personalizado de dados no Excel.</p>
     </b-card>
 </b-card-group>
 <hr />

--- a/locales/en.json
+++ b/locales/en.json
@@ -32,12 +32,18 @@
     "dashboards": "Dashboards:",
     "customise": "Customise",
     "customDownload": "Custom Data Download",
+    "customDownloadText": "Choose the columns to be included in your spreadsheet and select the filters to narrow your search. Download the custom set of data in Excel.",
+    "dataSource": "The source of this data is the organisations publishing data to IATI. The data is updated once per day to capture new or updated data published to the IATI Registry. Additional details can be found in the {methodology} section.",
+    "dataSourceContact": "For support or training, reach out to {emailContact}",
+    "emailContact": "support@iatistandard.org",
     "columns": "Columns",
     "selectColumns": "Select columns",
     "selectAtLeastOneColumn": "You must select at least one column",
     "dragColumnsToReorder": "Drag columns to reorder output",
     "deselect": "Deselect",
     "filters": "Filters",
+    "filtersText": "Select filters to customise the visualisation.",
+    "selectedFilters": "Filters applied",
     "preview": "Preview",
     "currency": "Currency",
     "calendarYear": "Calendar Year",
@@ -49,7 +55,7 @@
     "selectSomeOptions": "Select some options, and then click Run on the left.",
     "amount": "Value",
     "budgetsSpending": {
-      "budgetsOrSpending": "Spending Type",
+      "budgetsOrSpending": "Resource flows",
       "budgets": "Budgets",
       "spending": "Spending",
       "both": "Both"
@@ -60,7 +66,7 @@
       "toSimple": "Switch to simple: select budget and/or spending"
     },
     "reportingOrganisationGroup": {
-      "select": "Select groups of reporting organisations",
+      "select": "Select groups of reporting organisations for organisations that publish data under multiple reporting organisations.",
       "apply": "Apply",
       "label": "Reporting Organisation Group",
       "selectOne": "Select one..."
@@ -84,6 +90,7 @@
       "select": "Select a sector to explore the data."
     },
     "summary": "Summary",
+    "spendSummaryChartText": "This chart shows both budgets and spending for the previous three years, the current year, and the next three years. The resource flows and years/quarters filters have not been applied to this chart.",
     "exploreTheData": "Explore the data",
     "availableDrilldowns": {
       "activity.iati_identifier": "Activity IATI Identifier",
@@ -106,6 +113,12 @@
       "year.year": "Calendar Year",
       "quarter.quarter": "Calendar Quarter",
       "calendar_year_and_quarter.calendar_year_and_quarter": "Calendar Year and Quarter"
+    },
+    "unavailableDrilldowns": {
+      "transaction_type": "Resource Flows",
+      "year": "Calendar Year | Calendar Years",
+      "quarter": "Calendar Quarter | Calendar Quarters",
+      "calendar_year_and_quarter": "Calendar Year and Quarter | Calendar Years and Quarters"
     },
     "activity": "Activity"
   },

--- a/locales/es.json
+++ b/locales/es.json
@@ -32,12 +32,18 @@
     "dashboards": "Paneles:",
     "customise": "Personalizar",
     "customDownload": "Descarga de datos personalizados",
+    "customDownloadText": "Elija las columnas que se incluirán en su hoja de cálculo y seleccione los filtros para restringir su búsqueda. Descargue el conjunto personalizado de datos en Excel.",
+    "dataSource": "La fuente de estos datos son las organizaciones que publican datos en la IATI. Los datos se actualizan una vez al día para capturar datos nuevos o actualizados publicados en el Registro de la IATI. Se pueden encontrar detalles adicionales en la sección {methodology}.",
+    "dataSourceContact": "Para soporte o capacitación, comuníquese con {emailContact}",
+    "emailContact": "support@iatistandard.org",
     "columns": "Columnas",
     "selectColumns": "Seleccionar columnas",
     "selectAtLeastOneColumn": "Debe seleccionar al menos una columna",
     "dragColumnsToReorder": "Arrastre las columnas para cambiar el orden de los productos",
     "deselect": "Deseleccionar",
     "filters": "Filtros",
+    "filtersText": "Seleccione filtros para personalizar la visualización.",
+    "selectedFilters": "Filtros aplicados",
     "preview": "Vista previa",
     "currency": "Moneda",
     "calendarYear": "Año natural",
@@ -49,9 +55,9 @@
     "selectSomeOptions": "Seleccione algunas opciones y haga clic en “Ejecutar” a la izquierda.",
     "amount": "Valor",
     "budgetsSpending": {
-      "budgetsOrSpending": "Tipo de gasto",
+      "budgetsOrSpending": "Flujos de Recursos",
       "budgets": "Presupuestos",
-      "spending": "Gasto",
+      "spending": "Gastos",
       "both": "Ambos"
     },
     "transactionTypes": "Transaction Type",
@@ -60,10 +66,10 @@
       "toSimple": "Switch to simple: select budget and/or spending"
     },
     "reportingOrganisationGroup": {
-      "select": "Select groups of reporting organisations",
+      "select": "Seleccione grupos de organizaciones notificadoras para organizaciones que publican datos bajo varias organizaciones notificadoras.",
       "apply": "Apply",
-      "label": "Reporting Organisation Group",
-      "selectOne": "Select one..."
+      "label": "Grupos de Organizaciones Notificadoras",
+      "selectOne": "Seleccione un grupo..."
     },
     "countries": {
       "by": "por País o región receptores",
@@ -84,6 +90,7 @@
       "select": "Seleccione un sector para explorar los datos."
     },
     "summary": "Resumen",
+    "spendSummaryChartText": "Este gráfico muestra los presupuestos y gastos de los tres años anteriores, el año en curso y los tres años siguientes. Los filtros sobre flujos de recursos y años y trimestres naturales no se han aplicado a este gráfico.",
     "exploreTheData": "Explorar los datos",
     "availableDrilldowns": {
       "activity.iati_identifier": "Identificador de la IATI de la actividad",
@@ -106,6 +113,12 @@
       "year.year": "Año natural",
       "quarter.quarter": "Trimestre natural",
       "calendar_year_and_quarter.calendar_year_and_quarter": "Año y trimestre natural"
+    },
+    "unavailableDrilldowns": {
+      "transaction_type": "Flujos de Recursos",
+      "year": "Año natural",
+      "quarter": "Trimestre natural",
+      "calendar_year_and_quarter": "Año y trimestre naturales"
     },
     "activity": "Actividad"
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -23,7 +23,7 @@
       "text": "Analyser les données"
     }
   ],
-  "homepageLookingGuidanceAnalysis": "À la recherche des lignes directrices et des tableaux de bord d’analyse ? Nous avons déplacé ce contenu dans la section À propos.",
+  "homepageLookingGuidanceAnalysis": "À la recherche des lignes directrices et des tableaux de bord d’analyse? Nous avons déplacé ce contenu dans la section À propos.",
   "exploreDataDashboards": "Découvrez les tableaux de bord de données",
   "by": "par",
   "dataDashboards": {
@@ -32,12 +32,18 @@
     "dashboards": "Tableaux de bord :",
     "customise": "Personnaliser",
     "customDownload": "Téléchargement de données personnalisées",
+    "customDownloadText": "Choisissez les colonnes à inclure dans votre feuille de calcul et sélectionnez les filtres pour affiner votre recherche. Téléchargez l'ensemble de données personnalisé dans Excel.",
+    "dataSource": "La source de ces données sont les organisations qui publient des données à l'IITA. Les données sont mises à jour une fois par jour pour capturer les données nouvelles ou mises à jour publiées dans le Registre de l'IITA. Des détails supplémentaires peuvent être trouvés dans la section {methodology}.",
+    "dataSourceContact": "Pour le soutien ou une formation, contactez {emailContact}",
+    "emailContact": "support@iatistandard.org",
     "columns": "Colonnes",
     "selectColumns": "Sélectionner les colonnes",
     "selectAtLeastOneColumn": "Veuillez sélectionner au moins une colonne.",
     "dragColumnsToReorder": "Faites glisser les colonnes pour réorganiser la présentation des données.",
     "deselect": "Désélectionner",
     "filters": "Filtres",
+    "filtersText": "Sélectionnez des filtres pour personnaliser la visualisation.",
+    "selectedFilters": "Filtres appliqués ",
     "preview": "Aperçu",
     "currency": "Devise",
     "calendarYear": "Année civile",
@@ -49,10 +55,10 @@
     "selectSomeOptions": "Sélectionnez plusieurs options, puis lancez la recherche.",
     "amount": "Valeur",
     "budgetsSpending": {
-      "budgetsOrSpending": "Type de dépenses",
+      "budgetsOrSpending": "Flux de Ressources",
       "budgets": "Budgets",
       "spending": "Dépenses",
-      "both": "Budgets et dépenses"
+      "both": "Les deux"
     },
     "transactionTypes": "Transaction Type",
     "switchTransactionTypes": {
@@ -60,10 +66,10 @@
       "toSimple": "Switch to simple: select budget and/or spending"
     },
     "reportingOrganisationGroup": {
-      "select": "Select groups of reporting organisations",
+      "select": "Sélectionnez des groupes d'organisations déclarantes pour les organisations qui publient des données sous plusieurs organisations déclarantes.",
       "apply": "Apply",
-      "label": "Reporting Organisation Group",
-      "selectOne": "Select one..."
+      "label": "Groupes d'Organismes Déclarants",
+      "selectOne": "Sélectionner une groupe..."
     },
     "countries": {
       "by": "par Pays ou région bénéficiaire ",
@@ -75,7 +81,7 @@
       "by": "par Organisme déclarant",
       "label": "Organismes déclarants",
       "for": "Tableau de bord pour",
-      "select": "Choisir un prestataire pour explorer les données."
+      "select": "Choisir une organisme déclarant pour explorer les données."
     },
     "sectors": {
       "by": "par Secteur",
@@ -84,6 +90,7 @@
       "select": "Choisir un secteur pour explorer les données."
     },
     "summary": "Vue d’ensemble",
+    "spendSummaryChartText": "Ce graphique montre les budgets et les dépenses pour les trois années précédentes, l'année en cours et les trois années suivantes. Les filtres sur les flux de ressources et les années et trimestres civils n'ont pas été appliqués à ce graphique.",
     "exploreTheData": "Explorez les données",
     "availableDrilldowns": {
       "activity.iati_identifier": "Identifiant de l’IITA",
@@ -106,6 +113,12 @@
       "year.year": "Année civile",
       "quarter.quarter": "Trimestre civil",
       "calendar_year_and_quarter.calendar_year_and_quarter": "Année et trimestre civils"
+    },
+    "unavailableDrilldowns": {
+      "transaction_type": "Flux de Ressources",
+      "year": "Année civile",
+      "quarter": "Trimestre civil",
+      "calendar_year_and_quarter": "Année et trimestre civils"
     },
     "activity": "Activité"
   },

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -32,12 +32,18 @@
     "dashboards": "Painéis",
     "customise": "Personalizar",
     "customDownload": "Descarregar dados personalizados",
+    "customDownloadText": "Escolha as colunas a serem incluídas em sua planilha e selecione os filtros para refinar sua pesquisa. Baixe o conjunto personalizado de dados no Excel.",
+    "dataSource": "A fonte desses dados são as organizações que publicam dados para a IATI. Os dados são atualizados uma vez por dia para capturar dados novos ou atualizados publicados no Registo da IATI. Detalhes adicionais podem ser encontrados na seção {methodology}.",
+    "dataSourceContact": "Para suporte ou treinamento, entre em contato com {emailContact}",
+    "emailContact": "support@iatistandard.org",
     "columns": "Colunas",
     "selectColumns": "Selecionar colunas",
     "selectAtLeastOneColumn": "Tem de selecionar pelo menos uma coluna",
     "dragColumnsToReorder": "Arraste as colunas para reordenar o resultado",
     "deselect": "Anular a seleção",
     "filters": "Filtros",
+    "filtersText": "Selecione os filtros para personalizar a visualização.",
+    "selectedFilters": "Filtros aplicados",
     "preview": "Pré-visualização",
     "currency": "Moeda",
     "calendarYear": "Ano civil",
@@ -49,9 +55,9 @@
     "selectSomeOptions": "Selecione algumas opções e clique em Executar à esquerda.",
     "amount": "Valor",
     "budgetsSpending": {
-      "budgetsOrSpending": "Tipo de despesa",
+      "budgetsOrSpending": "Fluxos de Recursos",
       "budgets": "Orçamentos",
-      "spending": "Despesa",
+      "spending": "Despesas",
       "both": "Ambos"
     },
     "transactionTypes": "Transaction Type",
@@ -60,10 +66,10 @@
       "toSimple": "Switch to simple: select budget and/or spending"
     },
     "reportingOrganisationGroup": {
-      "select": "Select groups of reporting organisations",
+      "select": "Selecione grupos de organizações relatórios para organizações que publicam dados em várias organizações relatórios.",
       "apply": "Apply",
-      "label": "Reporting Organisation Group",
-      "selectOne": "Select one..."
+      "label": "Grupos Organizacionais Relatórios",
+      "selectOne": "Selecione um grupo..."
     },
     "countries": {
       "by": "por País ou região recetor",
@@ -84,6 +90,7 @@
       "select": "Selecione um sector para explorar os dados."
     },
     "summary": "Resumo",
+    "spendSummaryChartText": "Este gráfico mostra orçamentos e despesas para os três anos anteriores, para o ano corrente e para os três anos seguintes. Filtros sobre fluxos de recursos e anos civis e trimestres não foram aplicados a este gráfico.",
     "exploreTheData": "Explore os dados",
     "availableDrilldowns": {
       "activity.iati_identifier": "Identificador de atividade da IATI",
@@ -106,6 +113,12 @@
       "year.year": "Ano civil",
       "quarter.quarter": "Trimestre civil",
       "calendar_year_and_quarter.calendar_year_and_quarter": "Ano e trimestre civis"
+    },
+    "unavailableDrilldowns": {
+      "transaction_type": "Fluxos de Recurso",
+      "year": "Ano civil",
+      "quarter": "Trimestre civil",
+      "calendar_year_and_quarter": "Ano e trimestre civis"
     },
     "activity": "Atividade"
   },

--- a/pages/data/custom/index.vue
+++ b/pages/data/custom/index.vue
@@ -2,6 +2,7 @@
   <div class="custom-data-browser">
     <DataBrowserNavbar />
     <h1>{{ $t('dataDashboards.customDownload') }}</h1>
+    <p class="lead">{{ $t('dataDashboards.customDownloadText') }}</p>
     <b-row>
       <b-col md="3" class="mt-2">
         <h3>{{ $t('dataDashboards.columns') }}</h3>
@@ -87,6 +88,7 @@
          />
       </b-col>
     </b-row>
+    <DataBrowserSource />
   </div>
 </template>
 <style>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -23,6 +23,7 @@
           :pageSize="null"
           :clickable="true"
          />
+         <hr />
       </b-col>
     </b-row>
     <b-row>
@@ -35,6 +36,7 @@
           :currency.sync="currency"
           :clickable="true"
          />
+         <hr />
       </b-col>
     </b-row>
     <b-row>
@@ -47,8 +49,24 @@
           :currency.sync="currency"
           :clickable="true"
          />
+        <hr />
       </b-col>
     </b-row>
+    <b-row>
+      <b-col>
+        <h2>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns')['year.year'] }}</h2>
+        <DataBrowser
+          :drilldowns="['year.year']"
+          :setFields="summarySetFields"
+          :currency.sync="currency"
+          bar-chart-height="300px"
+          :show-number-results="false"
+          :pageSize="null"
+          orderBy="year.year" />
+        <p class="text-muted font-italic">{{ $t('dataDashboards.spendSummaryChartText') }}</p>
+      </b-col>
+    </b-row>
+    <DataBrowserSource />
   </div>
 </template>
 <script>
@@ -72,6 +90,21 @@ export default {
     }
   },
   computed: {
+    summarySetFields() {
+      return {
+        ...this.setFields,
+        ...{
+          year: this.calendarYears,
+          transaction_type: ['3', '4', 'budget']
+        }
+      }
+    },
+    calendarYears() {
+      var years = []
+      const year = new Date().getFullYear()
+      const range = (start, stop, step = 1) => Array.from({ length: (stop - start) / step + 1}, (_, i) => start + (i * step));
+      return range(year-3, year+3).map(year => { return `${year}` })
+    }
   },
   mounted: function() {
     this.$store.dispatch('getCodelists')

--- a/pages/data/recipient-country-or-region/_code/index.vue
+++ b/pages/data/recipient-country-or-region/_code/index.vue
@@ -7,6 +7,16 @@
     <hr />
     <b-row>
       <b-col>
+        <DataBrowserFilter
+          :exclude-filters="['recipient_country_or_region', 'transaction_type']"
+          :setFields.sync="setFields"
+          :currency.sync="currency"
+          pageName="data-recipient-country-or-region-code"
+        />
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
         <h2>{{ $t('dataDashboards.summary') }}</h2>
         <DataBrowser
           :drilldowns="['year.year']"
@@ -16,6 +26,7 @@
           :show-number-results="false"
           :pageSize="null"
           orderBy="year.year" />
+        <p class="text-muted font-italic">{{ $t('dataDashboards.spendSummaryChartText') }}</p>
       </b-col>
     </b-row>
     <b-row>
@@ -24,19 +35,13 @@
       </b-col>
     </b-row>
     <b-row>
-      <b-col md="12" class="mt-2">
+      <b-col class="mt-2">
         <h2>{{ $t('dataDashboards.exploreTheData') }}</h2>
-        <DataBrowserFilter
-          :exclude-filters="['recipient_country_or_region', 'transaction_type']"
-          :setFields.sync="setFields"
-          :currency.sync="currency"
-          pageName="data-recipient-country-or-region-code"
-         />
       </b-col>
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.reporting_organisation') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.reporting_organisation') }}</h3>
         <DataBrowser
           :drilldowns="['reporting_organisation']"
           :setFields="setFields"
@@ -44,7 +49,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.sector_category') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.sector_category') }}</h3>
         <DataBrowser
           :drilldowns="['sector_category']"
           :setFields="setFields"
@@ -59,7 +64,7 @@
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.finance_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.finance_type') }}</h3>
         <DataBrowser
           :drilldowns="['finance_type']"
           :setFields="setFields"
@@ -67,7 +72,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.aid_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.aid_type') }}</h3>
         <DataBrowser
           :drilldowns="['aid_type']"
           :setFields="setFields"
@@ -82,7 +87,7 @@
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.reporting_organisation_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.reporting_organisation_type') }}</h3>
         <DataBrowser
           :drilldowns="['reporting_organisation_type']"
           :setFields="setFields"
@@ -90,7 +95,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.humanitarian') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.humanitarian') }}</h3>
         <DataBrowser
           :drilldowns="['humanitarian']"
           :setFields="setFields"
@@ -114,6 +119,7 @@
          />
       </b-col>
     </b-row>
+    <DataBrowserSource />
   </div>
 </template>
 <script>
@@ -147,9 +153,11 @@ export default {
   computed: {
     summarySetFields() {
       return {
-        recipient_country_or_region: [this.$route.params.code],
-        transaction_type: ['3', '4', 'budget'],
-        year: this.calendarYears
+        ...this.setFields,
+        ...{
+          year: this.calendarYears,
+          transaction_type: ['3', '4', 'budget']
+        }
       }
     },
     calendarYears() {

--- a/pages/data/recipient-country-or-region/index.vue
+++ b/pages/data/recipient-country-or-region/index.vue
@@ -12,6 +12,7 @@
           v-bind:key="country.code">
           <nuxt-link
           variant="link"
+          :class="country.status == 'withdrawn' ? 'text-muted' : null"
           :to="localePath({
             name: `data-recipient-country-or-region-code`, params: { code: country.code }
           })">{{ country.name }}</nuxt-link>
@@ -23,6 +24,7 @@
         <b-spinner variant="secondary" />
       </div>
     </template>
+    <DataBrowserSource />
   </div>
 </template>
 <script>

--- a/pages/data/reporting-organisation/_code/index.vue
+++ b/pages/data/reporting-organisation/_code/index.vue
@@ -6,26 +6,7 @@
     </h1>
     <hr />
     <b-row>
-      <b-col>
-        <h2>{{ $t('dataDashboards.summary') }}</h2>
-        <DataBrowser
-          :drilldowns="['year.year']"
-          :setFields="summarySetFields"
-          :currency.sync="currency"
-          bar-chart-height="300px"
-          :show-number-results="false"
-          :pageSize="null"
-          orderBy="year.year"  />
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col>
-        <hr />
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col md="12" class="mt-2">
-        <h2>{{ $t('dataDashboards.exploreTheData') }}</h2>
+      <b-col class="mt-2">
         <DataBrowserFilter
           :exclude-filters="['reporting_organisation', 'reporting_organisation_type', 'transaction_type']"
           :setFields.sync="setFields"
@@ -35,8 +16,32 @@
       </b-col>
     </b-row>
     <b-row>
+      <b-col>
+        <h2>{{ $t('dataDashboards.summary') }}</h2>
+        <DataBrowser
+          :drilldowns="['year.year']"
+          :setFields="summarySetFields"
+          :currency.sync="currency"
+          bar-chart-height="300px"
+          :show-number-results="false"
+          :pageSize="null"
+          orderBy="year.year" />
+        <p class="text-muted font-italic">{{ $t('dataDashboards.spendSummaryChartText') }}</p>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
+        <hr />
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col class="mt-2">
+        <h2>{{ $t('dataDashboards.exploreTheData') }}</h2>
+      </b-col>
+    </b-row>
+    <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.recipient_country_or_region') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.recipient_country_or_region') }}</h3>
         <DataBrowser
           :drilldowns="['recipient_country_or_region']"
           displayAs="map"
@@ -46,7 +51,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.sector_category') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.sector_category') }}</h3>
         <DataBrowser
           :drilldowns="['sector_category']"
           :setFields="setFields"
@@ -61,7 +66,7 @@
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.finance_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.finance_type') }}</h3>
         <DataBrowser
           :drilldowns="['finance_type']"
           :setFields="setFields"
@@ -69,7 +74,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.aid_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.aid_type') }}</h3>
         <DataBrowser
           :drilldowns="['aid_type']"
           :setFields="setFields"
@@ -84,7 +89,7 @@
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.reporting_organisation_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.reporting_organisation_type') }}</h3>
         <DataBrowser
           :drilldowns="['reporting_organisation_type']"
           :setFields="setFields"
@@ -92,7 +97,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.humanitarian') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.humanitarian') }}</h3>
         <DataBrowser
           :drilldowns="['humanitarian']"
           :setFields="setFields"
@@ -116,6 +121,7 @@
          />
       </b-col>
     </b-row>
+    <DataBrowserSource />
   </div>
 </template>
 <script>
@@ -125,6 +131,7 @@ import DataBrowser from '~/components/DataBrowser'
 import DataBrowserFilter from '~/components/DataBrowserFilter'
 import DataBrowserNavbar from '~/components/DataBrowserNavbar'
 export default {
+  name: 'DataReportingOrganisationCode',
   components: { DataBrowser, DataBrowserFilter },
   data() {
     const lastYear = new Date().getFullYear()-1
@@ -149,9 +156,11 @@ export default {
   computed: {
     summarySetFields() {
       return {
-        reporting_organisation: [this.$route.params.code],
-        transaction_type: ['3', '4', 'budget'],
-        year: this.calendarYears
+        ...this.setFields,
+        ...{
+          year: this.calendarYears,
+          transaction_type: ['3', '4', 'budget']
+        }
       }
     },
     calendarYears() {

--- a/pages/data/reporting-organisation/index.vue
+++ b/pages/data/reporting-organisation/index.vue
@@ -8,13 +8,13 @@
     <template v-if="fields.reporting_organisation.length >0 ">
       <b-card-group columns>
         <b-card
-          v-for="provider in fields.reporting_organisation"
-          v-bind:key="provider.code">
+          v-for="reporting_organisation in fields.reporting_organisation"
+          v-bind:key="reporting_organisation.code">
           <nuxt-link
           variant="link"
           :to="localePath({
-            name: `data-reporting-organisation-code`, params: { code: provider.code }
-          })">{{ provider.name }}</nuxt-link>
+            name: `data-reporting-organisation-code`, params: { code: reporting_organisation.code }
+          })">{{ reporting_organisation.name }}</nuxt-link>
         </b-card>
       </b-card-group>
     </template>
@@ -23,6 +23,7 @@
         <b-spinner variant="secondary" />
       </div>
     </template>
+    <DataBrowserSource />
   </div>
 </template>
 <script>
@@ -30,6 +31,7 @@
 import { mapState } from 'vuex'
 import DataBrowserNavbar from '~/components/DataBrowserNavbar'
 export default {
+  name: 'DataReportingOrganisation',
   data() {
     return {
     }

--- a/pages/data/sector-category/_code/index.vue
+++ b/pages/data/sector-category/_code/index.vue
@@ -7,25 +7,6 @@
     <hr />
     <b-row>
       <b-col>
-        <h2>{{ $t('dataDashboards.summary') }}</h2>
-        <DataBrowser
-          :drilldowns="['year.year']"
-          :setFields="summarySetFields"
-          :currency.sync="currency"
-          bar-chart-height="300px"
-          :show-number-results="false"
-          :pageSize="null"
-          orderBy="year.year"  />
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col>
-        <hr />
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col md="12" class="mt-2">
-        <h2>{{ $t('dataDashboards.exploreTheData') }}</h2>
         <DataBrowserFilter
           :exclude-filters="['sector_category', 'transaction_type']"
           :setFields.sync="setFields"
@@ -35,8 +16,32 @@
       </b-col>
     </b-row>
     <b-row>
+      <b-col>
+        <h2>{{ $t('dataDashboards.summary') }}</h2>
+        <DataBrowser
+          :drilldowns="['year.year']"
+          :setFields="summarySetFields"
+          :currency.sync="currency"
+          bar-chart-height="300px"
+          :show-number-results="false"
+          :pageSize="null"
+          orderBy="year.year" />
+        <p class="text-muted font-italic">{{ $t('dataDashboards.spendSummaryChartText') }}</p>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>
+        <hr />
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col class="mt-2">
+        <h2>{{ $t('dataDashboards.exploreTheData') }}</h2>
+      </b-col>
+    </b-row>
+    <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.recipient_country_or_region') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.recipient_country_or_region') }}</h3>
         <DataBrowser
           :drilldowns="['recipient_country_or_region']"
           displayAs="map"
@@ -46,7 +51,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.reporting_organisation') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.reporting_organisation') }}</h3>
         <DataBrowser
           :drilldowns="['reporting_organisation']"
           :setFields="setFields"
@@ -61,7 +66,7 @@
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.finance_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.finance_type') }}</h3>
         <DataBrowser
           :drilldowns="['finance_type']"
           :setFields="setFields"
@@ -69,7 +74,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.aid_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.aid_type') }}</h3>
         <DataBrowser
           :drilldowns="['aid_type']"
           :setFields="setFields"
@@ -84,7 +89,7 @@
     </b-row>
     <b-row>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.reporting_organisation_type') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.reporting_organisation_type') }}</h3>
         <DataBrowser
           :drilldowns="['reporting_organisation_type']"
           :setFields="setFields"
@@ -92,7 +97,7 @@
          />
       </b-col>
       <b-col md="6" class="mt-2">
-        <h3>{{ $t('by') }} {{ $t('dataDashboards.availableDrilldowns.humanitarian') }}</h3>
+        <h3>{{ $t('by') }} {{ $tc('dataDashboards.availableDrilldowns.humanitarian') }}</h3>
         <DataBrowser
           :drilldowns="['humanitarian']"
           :setFields="setFields"
@@ -116,6 +121,7 @@
          />
       </b-col>
     </b-row>
+    <DataBrowserSource />
   </div>
 </template>
 <script>
@@ -149,9 +155,11 @@ export default {
   computed: {
     summarySetFields() {
       return {
-        sector_category: [this.$route.params.code],
-        transaction_type: ['3', '4', 'budget'],
-        year: this.calendarYears
+        ...this.setFields,
+        ...{
+          year: this.calendarYears,
+          transaction_type: ['3', '4', 'budget']
+        }
       }
     },
     calendarYears() {

--- a/pages/data/sector-category/index.vue
+++ b/pages/data/sector-category/index.vue
@@ -22,6 +22,7 @@
         <b-spinner variant="secondary" />
       </div>
     </template>
+    <DataBrowserSource />
   </div>
 </template>
 <script>


### PR DESCRIPTION
* Fallback to EN translations if there is no FR/ES/PT reporting organisation
* Add a range of clarifying text
* Move summary spend chart below filters and apply filters to it
* Show which filters have been applied