### PR TITLE
Fix Firefox CORS bug with download files

### DIFF
--- a/components/Download.vue
+++ b/components/Download.vue
@@ -13,6 +13,7 @@
   </div>
 </template>
 <script>
+import axios from 'axios'
 import { saveAs } from 'file-saver'
 export default {
   data() {
@@ -43,8 +44,7 @@ export default {
   methods: {
     async getActivitiesFile() {
       this.preparingFile = true
-      await this.$axios({url: this.url,
-        method: 'GET',
+      await axios.get(this.url, {method: 'GET',
         responseType: 'blob'}).then(response => {
         if (response.status === 200) {
           saveAs(


### PR DESCRIPTION
Fixes Firefox CORS bug with download file button. Switch to use the official `axios` library rather than the internal nuxtjs `axios` library.

Fixes https://github.com/iati-data-access/data-backend/issues/21
@IsabelBirds