### PR TITLE
Small tidying up of input fields

### DIFF
--- a/components/DataBrowserFilterItem.vue
+++ b/components/DataBrowserFilterItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="data-browser-filter-item">
     <b-form-group
       :label="fieldLabel">
       <b-input-group
@@ -62,6 +62,13 @@
     </b-form-group>
   </div>
 </template>
+<style>
+.iati-design-system--enabled .data-browser-filter-item .no-margin input {
+  /* height: 30px; */
+  line-height: 1.4;
+  margin: 4px 0 0;
+}
+</style>
 <style scoped>
 div.input-group.nowrap {
   flex-wrap: nowrap;
@@ -72,6 +79,9 @@ div.input-group.nowrap {
 }
 .btn-outline-secondary {
   border-color: rgba(60,60,60,0.26);
+}
+.iati-design-system--enabled .no-margin fieldset {
+  padding: 0px;
 }
 </style>
 <script>

--- a/components/DataBrowserNavbar.vue
+++ b/components/DataBrowserNavbar.vue
@@ -38,6 +38,12 @@
 <style lang="scss">
 .navbar-secondary {
   background-color: #eee !important;
+
+  input {
+    /* height: 30px; */
+    line-height: 1.4;
+    margin: 4px 0 0;
+  }
   .btn-link {
     color: #155366 !important;
     &:hover, &:focus, &:active {


### PR DESCRIPTION
Fixes #76

Currently looks like this
<img width="1786" height="384" alt="image" src="https://github.com/user-attachments/assets/313613e7-4125-4ea3-87a4-d4727810fb99" />

Now looks like this (perhaps still too much padding around elements but at least input groups are formatted correctly now)
<img width="2298" height="206" alt="image" src="https://github.com/user-attachments/assets/2945db67-7917-44e8-a7d6-600e422c3f79" />

